### PR TITLE
FIX: Updated the max gravatar pixel size to 2048px

### DIFF
--- a/jgravatar/src/jgravatar/Gravatar.java
+++ b/jgravatar/src/jgravatar/Gravatar.java
@@ -15,11 +15,11 @@ import org.apache.commons.lang.Validate;
  * A gravatar is a dynamic image resource that is requested from the
  * gravatar.com server. This class calculates the gravatar url and fetches
  * gravatar images. See http://en.gravatar.com/site/implement/url .
- * 
+ *
  * This class is thread-safe, Gravatar objects can be shared.
- * 
+ *
  * Usage example:
- * 
+ *
  * <code>
  * Gravatar gravatar = new Gravatar();
  * gravatar.setSize(50);
@@ -41,12 +41,12 @@ public final class Gravatar {
 	private GravatarDefaultImage defaultImage = DEFAULT_DEFAULT_IMAGE;
 
 	/**
-	 * Specify a gravatar size between 1 and 512 pixels. If you omit this, a
+	 * Specify a gravatar size between 1 and 2048 pixels. If you omit this, a
 	 * default size of 80 pixels is used.
 	 */
 	public void setSize(int sizeInPixels) {
-		Validate.isTrue(sizeInPixels >= 1 && sizeInPixels <= 512,
-				"sizeInPixels needs to be between 1 and 512");
+		Validate.isTrue(sizeInPixels >= 1 && sizeInPixels <= 2048,
+				"sizeInPixels needs to be between 1 and 2048");
 		this.size = sizeInPixels;
 	}
 


### PR DESCRIPTION
The maximum gravatar pixel size you can get is capped at 2048px. Greater numbers can be used in the request however 2048px is the maximum sized image that will be returned so I have changed the validation check to match this. See https://en.gravatar.com/site/implement/images/
